### PR TITLE
Turn Class-Basic Turn

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,0 +1,42 @@
+class Turn
+  attr_reader :player1, :player2, :spoils_of_war
+
+  def initialize(player1, player2)
+    @player1 = player1
+    @player2 = player2
+    @spoils_of_war = Array.new
+  end
+
+  def type
+    if player1.deck.rank_of_card_at(0) != player2.deck.rank_of_card_at(0)
+      return :basic
+    elsif player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0)
+      return :war
+    elsif player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0) && player1.deck.rank_of_card_at(2) == player2.deck.rank_of_card_at(2)
+      return :mutually_assured_destruction
+    end
+  end
+
+  def winner
+    if player1.deck.rank_of_card_at(0) > player2.deck.rank_of_card_at(0)
+    player1
+    else
+    player2
+    end
+  end
+
+  def pile_cards
+    if type == :basic
+      @spoils_of_war.append(player1.deck.cards.shift)
+      @spoils_of_war.append(player2.deck.cards.shift)
+    elsif type == :war
+    elsif type == :mutually_assured_destruction
+    end
+  end
+
+  def award_spoils(winner)
+    winner.deck.cards << @spoils_of_war
+    winner.deck.cards.flatten!
+  end
+
+end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -1,0 +1,54 @@
+require_relative '../lib/deck'
+require_relative '../lib/card'
+require_relative '../lib/player'
+require_relative '../lib/turn'
+
+
+RSpec.describe Turn do
+  before(:each) do
+    @card1 = Card.new(:heart, 'Jack', 11)
+    @card2 = Card.new(:heart, '10', 10)
+    @card3 = Card.new(:heart, '9', 9)
+    @card4 = Card.new(:diamond, 'Jack', 11)
+    @card5 = Card.new(:heart, '8', 8)
+    @card6 = Card.new(:diamond, 'Queen', 12)
+    @card7 = Card.new(:heart, '3', 3)
+    @card8 = Card.new(:diamond, '2', 2)
+
+    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
+    @deck2 = Deck.new([@card3, @card4, @card6, @card7])
+
+    @player1 = Player.new('Nathan', @deck1)
+    @player2 = Player.new('Jessa', @deck2)
+
+    @turn = Turn.new(@player1, @player2)
+  end
+
+  it "exists and has attributes" do
+    expect(@turn).to be
+    expect(@turn.player1).to be(@player1)
+    expect(@turn.player2).to be(@player2)
+    expect(@turn.spoils_of_war).to eq([])
+  end
+
+  it "determines if the turn is :basic" do
+    expect(@turn.type).to eq(:basic)
+  end
+
+  it "determines a winner" do
+    expect(@turn.winner).to eq(@player1)
+  end
+
+  it "sends the players cards for the turn to the spoils of war" do
+    expect(@turn.spoils_of_war).to eq([])
+
+    @turn.pile_cards
+
+    expect(@turn.spoils_of_war).to eq([@card1, @card3])
+
+    @turn.award_spoils(@turn.winner)
+
+    expect(@turn.player2.deck.cards).to eq([@card4, @card6, @card7, @card1, @card3])
+    expect(@turn.player1.deck.cards).to eq([@card2, @card5, @card8])
+  end
+end


### PR DESCRIPTION
Add a spec and functionality for a basic war turn. In turn where there is a clear winner and loser. The winner takes two cards as a spoil of war. 